### PR TITLE
Return failed planning result if time parameterization fails

### DIFF
--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_iterative_spline_parameterization.cpp
@@ -68,7 +68,10 @@ public:
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
+      {
         ROS_WARN("Time parametrization for the solution path failed.");
+        result = false;
+      }
     }
 
     return result;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_optimal_parameterization.cpp
@@ -71,7 +71,10 @@ public:
       TimeOptimalTrajectoryGeneration totg;
       if (!totg.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                   req.max_acceleration_scaling_factor))
+      {
         ROS_WARN("Time parametrization for the solution path failed.");
+        result = false;
+      }
     }
 
     return result;

--- a/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
+++ b/moveit_ros/planning/planning_request_adapter_plugins/src/add_time_parameterization.cpp
@@ -67,7 +67,10 @@ public:
       ROS_DEBUG("Running '%s'", getDescription().c_str());
       if (!time_param_.computeTimeStamps(*res.trajectory_, req.max_velocity_scaling_factor,
                                          req.max_acceleration_scaling_factor))
+      {
         ROS_WARN("Time parametrization for the solution path failed.");
+        result = false;
+      }
     }
 
     return result;


### PR DESCRIPTION
### Description

We switched to a new time parameterization and noticed that it sometimes failed on our input -- but instead of returning that planning failed, planning succeeded and the resulting trajectory had all times set to 0.  This PR makes the time parameterization plugins adjust the return boolean appropriately.

### Checklist
- [x ] **Required**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Optional: Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Optional: Decide if this should be cherry-picked to other current ROS branches (Indigo, Jade, Kinetic)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
